### PR TITLE
fix: initialize collection metadata

### DIFF
--- a/react-websocket/src/client/editor/utils.ts
+++ b/react-websocket/src/client/editor/utils.ts
@@ -15,7 +15,7 @@ export function setRoom(id: string) {
 export function initCollection(id = 'blocksuite-example') {
   const schema = new Schema().register(AffineSchemas);
   const collection = new DocCollection({ schema, id });
-
+  collection.meta.initialize();
   return collection;
 }
 


### PR DESCRIPTION
When attempting to run these examples, I got lots of errors because the metadata was not initialized. I believe this is required based on some other examples and the documentation.